### PR TITLE
add maio abbreviation in brazilian

### DIFF
--- a/latex/lbx/brazilian-abnt.lbx
+++ b/latex/lbx/brazilian-abnt.lbx
@@ -41,6 +41,14 @@
     \thefield{#1}}%
 }%
 
+
+% Months abbreviations >>>2
+
+\DeclareBibliographyStrings{%
+  may          = {{maio}{maio}},%
+}
+% <<<2
+
 % <<<
 
 % Publication details >>>1


### PR DESCRIPTION
De acordo com o Anexo A da NBR 6023:2018, o mês de maio, em português, é a exceção no uso de abreviação, devendo ter seu nome completo utilizado.
Em outros idiomas também ocorrem outras exceções, creio que eu vá depois analisar e corrigir se tiver algo necessário de correção.