### PR TITLE
Months abbreviations for spanish and french

### DIFF
--- a/latex/lbx/french-abnt.lbx
+++ b/latex/lbx/french-abnt.lbx
@@ -43,6 +43,16 @@
     \thefield{#1}}%
 }%
 
+% Months abbreviations >>>2
+
+\DeclareBibliographyStrings{%
+  january          = {{janvier}{janv\adddot}},
+  february         = {{f\'evrier}{f\'evr\adddot}},
+  april            = {{avril}{avril}},
+  july             = {{juillet}{juil\adddot}},
+}
+% <<<2
+
 % <<<
 
 % Publication details >>>1

--- a/latex/lbx/spanish-abnt.lbx
+++ b/latex/lbx/spanish-abnt.lbx
@@ -43,6 +43,17 @@
     \thefield{#1}}%
 }%
 
+% Months abbreviations >>>2
+
+\DeclareBibliographyStrings{%
+  january          = {{enero}{enero}},
+  march            = {{marzo}{marzo}},
+  may              = {{mayo}{mayo}},
+  august           = {{agosto}{agosto}},
+  september        = {{septiembre}{sept\adddot}},
+}
+% <<<2
+
 % <<<
 
 % Publication details >>>1


### PR DESCRIPTION
Adicionando as abreviações de meses de acordo com o Anexo A da NBR 6023:2018 no qual o biblatex não utiliza as mesmas abreviações.