### PR TITLE
Fixing double comma on number of (in)proceedings

### DIFF
--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -1420,10 +1420,12 @@
 \DeclareFieldFormat[% number >>>
   book,%
   collection,%
-  proceedings,%
-  inproceedings,%
   misc%
 ]{number}{\addcomma\addspace #1}%% <<<
+\DeclareFieldFormat[% number >>>
+  proceedings,%
+  inproceedings,%
+]{number}{\addspace #1}%% <<<
 % <<<
 
 \DeclareFieldFormat*{volume}{%% >>>4


### PR DESCRIPTION
Utilizando proceedings e inproceedings aqui em um documento, os números dos eventos, após organization ou eventtitle vinham com duas virgulas, só que minha correção está mais para contornar o bug do que realmente resolver. Eu não identifiquei bugs que eu possa ter causado com essa alteração, mas também não sei direito os impactos que possa ter causado em outras partes, então é necessário revisar.

Sendo bem honesto, sou bem iniciante no negócio de alterar pacotes no LaTeX, então ainda não sei bem exatamente onde minhas alterações podem afetar outras partes.