### PR TITLE
Add period at the end of reference

### DIFF
--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -763,10 +763,6 @@
   }{}
 }% <<<3
 
-\xpatchbibmacro{finentry}% >>>3
-  {\finentry}
-  {\adddot}{}{}% <<<3
-  
 % <<<2
 
 % <<<1
@@ -966,6 +962,13 @@
 \DeclareEntryOption[boolean]{backref}[true]{%
   \settoggle{backref}{#1}%
 }%
+% <<<2
+
+% Add a period at the end of every reference >>>2
+\DeclareBibliographyOption[boolean]{periodatend}[true]{%
+\xpatchbibmacro{finentry}%
+{\finentry}%
+{\adddot}{}{}}
 % <<<2
 
 % <<<1

--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -968,7 +968,7 @@
 \DeclareBibliographyOption[boolean]{periodatend}[true]{%
 \xpatchbibmacro{finentry}%
 {\finentry}%
-{\adddot}{}{}}
+{\addperiod}{}{}}
 % <<<2
 
 % <<<1

--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -763,6 +763,10 @@
   }{}
 }% <<<3
 
+\xpatchbibmacro{finentry}% >>>3
+  {\finentry}
+  {\adddot}{}{}% <<<3
+  
 % <<<2
 
 % <<<1


### PR DESCRIPTION
Lendo a NBR 6023:2018 percebi que todas as citações terminam com um ponto final, aí editei o comando para adicionar o ponto. Eu realmente não sei se isso é uma obrigação, então acho que talvez eu crie uma nova option para permitir o usuário alternar entre ponto final na referência ou não. Seria bacana saber a opinião de outras pessoas.