### PR TITLE
Add the option to use slash as daterangesep

### DIFF
--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -964,6 +964,12 @@
 }%
 % <<<2
 
+% Option per entry to use a slash / as the daterangesep >>>2
+\DeclareEntryOption[boolean]{slashdaterangesep}[true]{
+  \renewrobustcmd*{\bibdaterangesep}{\slash}%
+}
+% <<<2
+
 % <<<1
 
 


### PR DESCRIPTION
Criei uma opção, para usar por entrada, que permite escolher utilizar a barra como o separador de períodos de data. Eu considero essa opção importante pois permite, usando da boa prática, tanto ter registros com datas como 2000--2020 quanto outros como set./out. 2020, já que existem situações em que ambas as formas são necessárias. Isso evita a necessidade de usar boa parte das gambiarras utilizando o campo issue para uma boa quantia de situações.

Por exemplo, quando é necessário que seja um travessão como separador:
```
@periodical{revista:nursing-1929,
  keywords       = {7.7,7.7.1},
  title          = {Nursing},
  location       = {Bruxelles},
  publisher      = {Association Nationale Catholique du Nursing},
  year           = {1929},
  endyear        = {1975},
  issn           = {0029-6457},
  note           = {Bimestral},
}
```

E quando é necessário usar barra para separar:
```
@article{artigo:lucca-2009,
  keywords          = {7.7,7.7.5},
  author            = {Gabriella {De Lucca}},
  title             = {Notas curtas},
  journaltitle      = {Getulio},
  location          = {São Paulo},
  volume            = {ano 3},
  pages             = {9},
  % Alternativa 1:
  date              = {2009-07/2009-08},
  % Alternativa 2:
  % month             = {07},
  % year              = {2009},
  % endmonth          = {08},
  % endyear           = {2009},  
  options        = {slashdaterangesep}
}
```