### PR TITLE
All months in lbx

### DIFF
--- a/latex/lbx/brazil-abnt.lbx
+++ b/latex/lbx/brazil-abnt.lbx
@@ -15,7 +15,7 @@
 \ProvidesFile{brazil-abnt.lbx}
 [2018-11-17\space v3.4\space ABNT BibLaTeX citation style]%
 
-\InheritBibliographyExtras{brazilian}
-\InheritBibliographyStrings{brazilian}
+\InheritBibliographyExtras{brazilian-abnt}
+\InheritBibliographyStrings{brazilian-abnt}
 
 \endinput

--- a/latex/lbx/brazilian-abnt.lbx
+++ b/latex/lbx/brazilian-abnt.lbx
@@ -45,7 +45,18 @@
 % Months abbreviations >>>2
 
 \DeclareBibliographyStrings{%
-  may          = {{maio}{maio}},%
+  january          = {{janeiro}{jan\adddot}},%
+  february         = {{fevereiro}{fev\adddot}},%
+  march            = {{mar\c{c}o}{mar\adddot}},%
+  april            = {{abril}{abr\adddot}},%
+  may              = {{maio}{maio}},%
+  june             = {{junho}{jun\adddot}},%
+  july             = {{julho}{jul\adddot}},%
+  august           = {{agosto}{ago\adddot}},%
+  september        = {{setembro}{set\adddot}},%
+  october          = {{outubro}{out\adddot}},%
+  november         = {{novembro}{nov\adddot}},%
+  december         = {{dezembro}{dez\adddot}},%
 }
 % <<<2
 

--- a/latex/lbx/english-abnt.lbx
+++ b/latex/lbx/english-abnt.lbx
@@ -43,6 +43,23 @@
     \thefield{#1}}%
 }%
 
+% Months abbreviations >>>2
+\DeclareBibliographyStrings{%
+  january          = {{January}{Jan\adddot}},
+  february         = {{February}{Feb\adddot}},
+  march            = {{March}{Mar\adddot}},
+  april            = {{April}{Apr\adddot}},
+  may              = {{May}{May}},
+  june             = {{June}{June}},
+  july             = {{July}{July}},
+  august           = {{August}{Aug\adddot}},
+  september        = {{September}{Sept\adddot}},
+  october          = {{October}{Oct\adddot}},
+  november         = {{November}{Nov\adddot}},
+  december         = {{December}{Dec\adddot}},
+}
+% <<<2
+
 % <<<
 
 % Publication details >>>1

--- a/latex/lbx/french-abnt.lbx
+++ b/latex/lbx/french-abnt.lbx
@@ -48,8 +48,16 @@
 \DeclareBibliographyStrings{%
   january          = {{janvier}{janv\adddot}},
   february         = {{f\'evrier}{f\'evr\adddot}},
+  march            = {{mars}{mars}},
   april            = {{avril}{avril}},
+  may              = {{mai}{mai}},
+  june             = {{juin}{juin}},
   july             = {{juillet}{juil\adddot}},
+  august           = {{ao\^ut}{ao\^ut}},
+  september        = {{septembre}{sept\adddot}},
+  october          = {{octobre}{oct\adddot}},
+  november         = {{novembre}{nov\adddot}},
+  december         = {{d\'ecembre}{d\'ec\adddot}},
 }
 % <<<2
 

--- a/latex/lbx/german-abnt.lbx
+++ b/latex/lbx/german-abnt.lbx
@@ -1,0 +1,38 @@
+%% Copyright 2016 Daniel Ballester Marques
+%%
+%% This work may be distributed and/or modified under the
+%% conditions of the LaTeX Project Public License, either version 1.3
+%% of this license or (at your option) any later version.
+%% The latest version of this license is in
+%%   http://www.latex-project.org/lppl.txt
+%% and version 1.3 or later is part of all distributions of LaTeX
+%% version 2005/12/01 or later.
+%%
+%% This work has the LPPL maintenance status `maintained'.
+%%
+%% The Current Maintainer of this work is Daniel Ballester Marques.
+
+\ProvidesFile{german-abnt.lbx}
+[2018-11-17\space v3.4\space ABNT BibLaTeX citation style]%
+
+\InheritBibliographyExtras{german}
+\InheritBibliographyStrings{german}
+
+% Months abbreviations >>>1
+\DeclareBibliographyStrings{%
+    january          = {{Januar}{Jan\adddot}},
+    february         = {{Februar}{Feb\adddot}},
+    march            = {{M\"arz}{M\"arz}},
+    april            = {{April}{Apr\adddot}},
+    may              = {{Mai}{Mai}},
+    june             = {{Juni}{Juni}},
+    july             = {{Juli}{Juli}},
+    august           = {{August}{Aug\adddot}},
+    september        = {{September}{Sept\adddot}},
+    october          = {{Oktober}{Okt\adddot}},
+    november         = {{November}{Nov\adddot}},
+    december         = {{Dezember}{Dez\adddot}},
+}
+% <<<1
+
+\endinput

--- a/latex/lbx/german-abnt.lbx
+++ b/latex/lbx/german-abnt.lbx
@@ -17,6 +17,9 @@
 
 \InheritBibliographyExtras{german}
 \InheritBibliographyStrings{german}
+\DeclareBibliographyStrings{%
+  inherit = {german},%
+}%
 
 % Months abbreviations >>>1
 \DeclareBibliographyStrings{%

--- a/latex/lbx/italian-abnt.lbx
+++ b/latex/lbx/italian-abnt.lbx
@@ -1,0 +1,38 @@
+%% Copyright 2016 Daniel Ballester Marques
+%%
+%% This work may be distributed and/or modified under the
+%% conditions of the LaTeX Project Public License, either version 1.3
+%% of this license or (at your option) any later version.
+%% The latest version of this license is in
+%%   http://www.latex-project.org/lppl.txt
+%% and version 1.3 or later is part of all distributions of LaTeX
+%% version 2005/12/01 or later.
+%%
+%% This work has the LPPL maintenance status `maintained'.
+%%
+%% The Current Maintainer of this work is Daniel Ballester Marques.
+
+\ProvidesFile{italian-abnt.lbx}
+[2018-11-17\space v3.4\space ABNT BibLaTeX citation style]%
+
+\InheritBibliographyExtras{italian}
+\InheritBibliographyStrings{italian}
+
+% Months abbreviations >>>1
+\DeclareBibliographyStrings{%
+    january          = {{gennaio}{genn\adddot}},
+    february         = {{febbraio}{febbr\adddot}},
+    march            = {{marzo}{mar\adddot}},
+    april            = {{aprile}{apr\adddot}},
+    may              = {{maggio}{magg\adddot}},
+    june             = {{giugno}{giugno}},
+    july             = {{luglio}{luglio}},
+    august           = {{agosto}{ag\adddot}},
+    september        = {{settembre}{sett\adddot}},
+    october          = {{ottobre}{ott\adddot}},
+    november         = {{novembre}{nov\adddot}},
+    december         = {{dicembre}{dic\adddot}},
+}
+% <<<1
+
+\endinput

--- a/latex/lbx/italian-abnt.lbx
+++ b/latex/lbx/italian-abnt.lbx
@@ -17,21 +17,24 @@
 
 \InheritBibliographyExtras{italian}
 \InheritBibliographyStrings{italian}
+\DeclareBibliographyStrings{%
+  inherit = {italian},%
+}%
 
 % Months abbreviations >>>1
 \DeclareBibliographyStrings{%
-    january          = {{gennaio}{genn\adddot}},
-    february         = {{febbraio}{febbr\adddot}},
-    march            = {{marzo}{mar\adddot}},
-    april            = {{aprile}{apr\adddot}},
-    may              = {{maggio}{magg\adddot}},
-    june             = {{giugno}{giugno}},
-    july             = {{luglio}{luglio}},
-    august           = {{agosto}{ag\adddot}},
-    september        = {{settembre}{sett\adddot}},
-    october          = {{ottobre}{ott\adddot}},
-    november         = {{novembre}{nov\adddot}},
-    december         = {{dicembre}{dic\adddot}},
+  january          = {{gennaio}{genn\adddot}},
+  february         = {{febbraio}{febbr\adddot}},
+  march            = {{marzo}{mar\adddot}},
+  april            = {{aprile}{apr\adddot}},
+  may              = {{maggio}{magg\adddot}},
+  june             = {{giugno}{giugno}},
+  july             = {{luglio}{luglio}},
+  august           = {{agosto}{ag\adddot}},
+  september        = {{settembre}{sett\adddot}},
+  october          = {{ottobre}{ott\adddot}},
+  november         = {{novembre}{nov\adddot}},
+  december         = {{dicembre}{dic\adddot}},
 }
 % <<<1
 

--- a/latex/lbx/spanish-abnt.lbx
+++ b/latex/lbx/spanish-abnt.lbx
@@ -47,10 +47,17 @@
 
 \DeclareBibliographyStrings{%
   january          = {{enero}{enero}},
+  february         = {{febrero}{feb\adddot}},
   march            = {{marzo}{marzo}},
+  april            = {{abril}{abr\adddot}},
   may              = {{mayo}{mayo}},
+  june             = {{junio}{jun\adddot}},
+  july             = {{julio}{jul\adddot}},
   august           = {{agosto}{agosto}},
   september        = {{septiembre}{sept\adddot}},
+  october          = {{octubre}{oct\adddot}},
+  november         = {{noviembre}{nov\adddot}},
+  december         = {{diciembre}{dic\adddot}},
 }
 % <<<2
 


### PR DESCRIPTION
Adicionei todas as strings restantes de meses, para garantir que siga o padrão de abreviação feito pela ABNT em português, espanhol e francês. Adicionalmente, fiz o mesmo com inglês, mesmo que já estivessem corretas. Além disso, criei os lbx dos idiomas de italiano e alemão só para adicionar os meses também, para que, quando usem o langid (mesmo que atualmente isto não esteja funcionando), pegue as abreviações corretas dos meses (sim, haviam diferenças entre as abreviações da NBR e as do biblatex). Também fiz um ajuste para que o brazil-abnt herde de brazilian-abnt, não sei se fiz certo.

Sobre os idiomas novos criados, peço que olhe com cuidado, para ver se eu não fiz alguma cagadinha na hora.