### PR TITLE
Fix bug that ignores the langid

### DIFF
--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -29,7 +29,7 @@
 \RequireBibliographyStyle{standard}%
 
 \ExecuteBibliographyOptions{%
-  language=brazil,%
+  % language=brazil,%
   block=none,%
   urldate=long,%
   pagetracker,%


### PR DESCRIPTION
Eu não sei se ela tinha grande impacto, mas comentei a linha que impedia o funcionamento correto no uso do `langid`. Se aquele comando for realmente importante, em primeiro momento, dá pra ignorar esse PR e tentar resolver uma das duas coisas por outros meios. Se a função dela é só pra deixar as referências por padrão como do idioma português, usando o babel, o biblatex já identifica e deixa no idioma principal, se não estou enganado.