### PR TITLE
Update slashdaterange option

### DIFF
--- a/doc/biblatex-abnt.bib
+++ b/doc/biblatex-abnt.bib
@@ -129,7 +129,7 @@
     year        = {2013},
 }
 
-@article{artigo:lucca-2009,
+@article{lucca2009,
   keywords          = {7.7,7.7.5},
   author            = {Gabriella {De Lucca}},
   title             = {Notas curtas},

--- a/doc/biblatex-abnt.bib
+++ b/doc/biblatex-abnt.bib
@@ -144,5 +144,5 @@
   % year              = {2009},
   % endmonth          = {08},
   % endyear           = {2009},  
-  options           = {slashdaterangesep}
+  options           = {slashdaterange}
 }

--- a/doc/biblatex-abnt.tex
+++ b/doc/biblatex-abnt.tex
@@ -169,6 +169,7 @@ daquelas descritas no manual do pacote):
     mas substitui os autores por traços sublineares
   \item [usedashes] Usa os traços padrão do \texttt{biblatex} nos campos
     repetidos
+  \item [slashdaterange] Utiliza uma barra ao invés do caractere padrão para separar períodos de datas. Sua utilização é mais recomendada para apenas entradas específicas
   \item [language=brazil] Essa opção é adicionada automaticamente. Para
     imprimir a bibliografia em outros idiomas, substitua o termo
     \texttt{brazil} pelo código da linguagem desejada
@@ -182,11 +183,9 @@ daquelas descritas no manual do pacote):
 \vspace{\baselineskip}
 E.g.: \verb"\usepackage[backend=biber, style=abnt, ittitles]{biblatex}"
 
-\subsection{Opções em entradas específicas}
-
 \begin{sloppypar}
   As opções \texttt{repeatfields}, \texttt{repeattitles}, \texttt{backref},
-  \texttt{nosl}, \texttt{nosn}, \texttt{noslsn} e \texttt{extrayear} também
+  \texttt{nosl}, \texttt{nosn}, \texttt{noslsn}, \texttt{extrayear} e \texttt{slashdaterange} também
   podem ser usadas apenas em entradas específicas. E.g.:
 \end{sloppypar}
 
@@ -199,10 +198,9 @@ E.g.: \verb"\usepackage[backend=biber, style=abnt, ittitles]{biblatex}"
     }
 \end{verbatim}
 
-    Além disso, também existe a opção \texttt{slashdaterange}, exclusiva para utilização em entradas. Ela permite definir para uma entrada utilizar a barra como o  separador de período de datas. E.g.:
-
+Ou, um exemplo de uso do \texttt{slashdaterange}:
 \begin{verbatim}
-    @article{artigo:lucca-2009,
+    @article{lucca2009,
         author            = {Gabriella {De Lucca}},
         title             = {Notas curtas},
         journaltitle      = {Getulio},
@@ -215,7 +213,7 @@ E.g.: \verb"\usepackage[backend=biber, style=abnt, ittitles]{biblatex}"
 \end{verbatim}
 
     Que resulta em:
-    \singlecite{artigo:lucca-2009}
+    \singlecite{lucca2009}
     
 % <<<2
 

--- a/doc/biblatex-abnt.tex
+++ b/doc/biblatex-abnt.tex
@@ -199,7 +199,7 @@ E.g.: \verb"\usepackage[backend=biber, style=abnt, ittitles]{biblatex}"
     }
 \end{verbatim}
 
-    Além disso, também existe a opção \texttt{slashdaterangesep}, exclusiva para utilização em entradas. Ela permite definir para uma entrada utilizar a barra como o  separador de período de datas. E.g.:
+    Além disso, também existe a opção \texttt{slashdaterange}, exclusiva para utilização em entradas. Ela permite definir para uma entrada utilizar a barra como o  separador de período de datas. E.g.:
 
 \begin{verbatim}
     @article{artigo:lucca-2009,
@@ -210,7 +210,7 @@ E.g.: \verb"\usepackage[backend=biber, style=abnt, ittitles]{biblatex}"
         volume            = {ano 3},
         pages             = {9},
         date              = {2009-07/2009-08},  
-        options           = {slashdaterangesep}
+        options           = {slashdaterange}
     }
 \end{verbatim}
 

--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -964,10 +964,13 @@
 }%
 % <<<2
 
-% Option per entry to use a slash / as the daterangesep >>>2
-\DeclareEntryOption[boolean]{slashdaterange}[true]{
-  \renewrobustcmd*{\bibdaterangesep}{\slash}%
-}
+% Option to use a slash / as the daterangesep >>>2
+\DeclareBibliographyOption[boolean]{slashdaterange}[true]{%
+\renewrobustcmd*{\bibdaterangesep}{\slash}%
+}%
+\DeclareEntryOption[boolean]{slashdaterange}[true]{%
+\renewrobustcmd*{\bibdaterangesep}{\slash}%
+}%
 % <<<2
 
 % <<<1

--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -965,7 +965,7 @@
 % <<<2
 
 % Option per entry to use a slash / as the daterangesep >>>2
-\DeclareEntryOption[boolean]{slashdaterangesep}[true]{
+\DeclareEntryOption[boolean]{slashdaterange}[true]{
   \renewrobustcmd*{\bibdaterangesep}{\slash}%
 }
 % <<<2


### PR DESCRIPTION
Renomeei a opção para slashdaterange
Adicionei como uma opção de bibliografia, para poder utilizar como o separador de períodos de datas padrão, se o usuário assim quiser
Atualizei a documentação sobre a opção
Resolvi o bug que o slashdaterange causava em algumas citações (que havia sido identificado ocorrendo apenas usando o abnt-numeric)