### PR TITLE
Bugfix the first letter on editortype

### DIFF
--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -1352,8 +1352,8 @@
 
 % Standard entry fields >>>3
 
-\DeclareFieldFormat{authortype}{\printtext[parens]{\bibsentence#1}}%
-\DeclareFieldFormat{editortype}{\printtext[parens]{\bibsentence#1}}%
+\DeclareFieldFormat{authortype}{\printtext[parens]{\midsentence#1}}%
+\DeclareFieldFormat{editortype}{\printtext[parens]{\midsentence#1}}%
 
 \DeclareFieldFormat{nameaddon}{\addspace #1}%
 


### PR DESCRIPTION
Corrigi o "bug" que fazia com que a descrição do campo `editortype` entre parênteses iniciasse com letra maiúscula, já que a norma atual pede que o "(org.)" e etc. venha em letras minúsculas.

Eu não sei bem quais são os issues que citam sobre esse bug, então, não sei como documentar corretamente para citar e relacionar o PR com os devidos issues.