### PR TITLE
Creating inthesis type

### DIFF
--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -1413,6 +1413,7 @@
   incollection,%
   bookinbook,%
   inproceedings,%
+  inthesis,%
   unpublished%
 ]{title}{\addspace #1\isdot}%% <<<
 
@@ -2657,6 +2658,64 @@
     {}%
   \usebibmacro{finentry}%
 }%% <<<2
+
+\DeclareBibliographyDriver{inthesis}{%% >>>2
+  \usebibmacro{bibindex}%
+  \usebibmacro{begentry}%
+  \usebibmacro{author/editor+others}%
+  \setunit{\labelnamepunct}%
+  \usebibmacro{title}%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \usebibmacro{in:bookauthor+others}%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \usebibmacro{maintitle/booktitle}%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \usebibmacro{date}%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \usebibmacro{chapter+pages}%
+  \newunit%
+  \printfield{pagetotal}%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \printfield{type}%
+  \setunit*{\addspace\textendash\addspace}%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \printlist{institution}%
+  \setunit*{\addcomma\addspace}%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \printlist{location}%
+  \setunit*{\addcomma\addspace}%
+  \printeventdate%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \printfield{note}%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \printunit{\addperiod\addspace}%
+  \iftoggle{bbx:isbn}%
+    {\printfield{isbn}}%
+    {}%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \usebibmacro{doi+eprint+url}%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \usebibmacro{addendum+pubstate}%
+  \setunit{\bibpagerefpunct}%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \usebibmacro{pageref}%
+  \setunit*{\addperiod\addspace}%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \iftoggle{bbx:related}%
+    {\usebibmacro{related:init}%
+     \usebibmacro{related}}%
+    {}%
+  \usebibmacro{finentry}%
+}%% >>>2
 
 \DeclareBibliographyDriver{misc}{%% >>>2
   \usebibmacro{bibindex}%

--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -2676,8 +2676,8 @@
   \usebibmacro{date}%
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  \usebibmacro{chapter+pages}%
-  \newunit%
+  % \usebibmacro{chapter+pages}%
+  % \newunit%
   \printfield{pagetotal}%
   \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -2691,6 +2691,8 @@
   \setunit*{\addcomma\addspace}%
   \printeventdate%
   \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \printfield{pages}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \printfield{note}%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Criei o tipo `@inthesis` para referenciar partes de trabalhos acadêmicos. Acho que dificilmente esse tipo será utilizado, mas como a NBR 6023:2018 na seção 7.3 dá um exemplo assim, foi necessário implementar para garantir a boa prática na hora de criar o exemplo.

Não sei se é bug, mas utilizar crossref ou related não está funcionando corretamente para este tipo, se a pessoa estiver tentando evitar digitar todos os dados novamente. Acredito que isso ocorra, pelo menos para o caso do related, por causa que o nome do autor, o `author` da obra completa, não é utilizado como `bookauthor`, aí então, depois do _In:_, vem o título com primeira palavra em caixa alta, como se não existisse autoria do "livro".

Segue o exemplo da NBR 6023:2018 utilizando esse tipo de entrada:
```
@inthesis{rodrigues2009parte,
    keywords        = {7.3},
    author          = {Ana Lúcia Aquilas Rodrigues},
    title           = {Aspectos éticos},
    booktitle       = {Impacto de um programa de exercícios no local de trabalho sobre o nível de atividade física e o estágio de prontidão para a mudança de comportamento},
    bookauthor      = {Ana Lúcia Aquilas Rodrigues},
    date            = {2009},
    type            = {Dissertação (Mestrado em Fisiopatologia Experimental)},
    institution     = {Faculdade de Medicina, Universidade de São Paulo},
    location        = {São Paulo},
    eventdate       = {2009},
    pages           = {19-20},
    bookpagination  = {sheet},
}
```