### PR TITLE
Add documentation of inthesis type

### DIFF
--- a/doc/biblatex-abnt.bib
+++ b/doc/biblatex-abnt.bib
@@ -146,3 +146,18 @@
   % endyear           = {2009},  
   options           = {slashdaterange}
 }
+
+@inthesis{rodrigues2009parte,
+    keywords        = {7.3},
+    author          = {Ana Lúcia Aquilas Rodrigues},
+    title           = {Aspectos éticos},
+    booktitle       = {Impacto de um programa de exercícios no local de trabalho sobre o nível de atividade física e o estágio de prontidão para a mudança de comportamento},
+    bookauthor      = {Ana Lúcia Aquilas Rodrigues},
+    date            = {2009},
+    type            = {Dissertação (Mestrado em Fisiopatologia Experimental)},
+    institution     = {Faculdade de Medicina, Universidade de São Paulo},
+    location        = {São Paulo},
+    eventdate       = {2009},
+    pages           = {19-20},
+    bookpagination  = {sheet},
+}

--- a/doc/biblatex-abnt.tex
+++ b/doc/biblatex-abnt.tex
@@ -762,6 +762,32 @@ Uma tese de doutorado:
 \singlecite{amaral15}
 % <<<3
 
+\subsection{@inthesis}% >>>3
+    Parte de um trabalho acadêmico (e.g.: monografia, tese ou dissertação):
+
+\begin{verbatim}
+    @inthesis{rodrigues2009parte,
+        author         = {Ana Lúcia Aquilas Rodrigues},
+        title          = {Aspectos éticos},
+        booktitle      = {Impacto de um programa de exercícios 
+                       no local de trabalho sobre o nível de atividade 
+                       física e o estágio de prontidão para a mudança 
+                       de comportamento},
+        bookauthor     = {Ana Lúcia Aquilas Rodrigues},
+        date           = {2009},
+        type           = {Dissertação (Mestrado em Fisiopatologia 
+                       Experimental)},
+        institution    = {Faculdade de Medicina, Universidade de São Paulo},
+        location       = {São Paulo},
+        eventdate      = {2009},
+        pages          = {19-20},
+        bookpagination = {sheet},
+    }
+\end{verbatim}
+
+\singlecite{rodrigues2009parte}
+% <<<3
+
 \subsection{@inproceedings}% >>>3
 
 Trabalhos publicados em resumos ou anais de eventos:


### PR DESCRIPTION
Adicionei a documentação do tipo `@inthesis`, mais para deixar os usuários saberem que existe (mesmo que dificilmente alguém utilize). Só fiquei na dúvida por causa que a documentação chama a seção de entradas comuns, aí só não sei o quão comum é esse tipo de entrada para estar nessa seção.

Algo que posso me comprometer a fazer, quando estiver próximo de concluir a versão do pacote para enviar ao CTAN é reformular a documentação para abordar melhor as particularidades do biblatex-abnt, deixando mais didática, podendo, inclusive, seguir um pouco a estrutura apresentada na NBR 6023:2018, para facilitar para o usuário se guiar pela documentação. Por exemplo, eu me lembro que quando estava aprendendo a utilizar o bibtex e biblatex eu penei demais para descobrir como referenciar leis e outras coisas do tipo, então acho que pode ser muito bacana tentar adicionar uma camada mais didática à documentação para os usuários que recém estão aprendendo sobre LaTeX ou só querem saber o suficiente para fazer seus trabalhos (que acabam sendo a maioria dos usuários).