### PR TITLE
Date options for entrytype

### DIFF
--- a/doc/biblatex-abnt.tex
+++ b/doc/biblatex-abnt.tex
@@ -158,6 +158,8 @@ daquelas descritas no manual do pacote):
   \item [giveninits] Abrevia os primeiros nomes na bibliografia
   \item [extrayear] Diferencia os anos com letras (e.g., 2017a)
     também na bibliografia
+  \item [dateyear] Imprime apenas o ano das entradas, descartando todas as outras partes da data. Se utilizada como uma opção global, recomenda-se o uso da opção \texttt{date=year} em seu lugar (menor risco de bugs)
+  \item [datemonth] Imprime apenas o mês e ano das entradas, descartando todas as outras partes da data
   \item [nosl] Oculta as abreviações [s.l.] na bibliografia
   \item [nosn] Oculta as abreviações [s.n.] na bibliografia
   \item [noslsn] Oculta as abreviações [s.l], [s.n] e [s.l.: s.n.]
@@ -185,7 +187,7 @@ E.g.: \verb"\usepackage[backend=biber, style=abnt, ittitles]{biblatex}"
 
 \begin{sloppypar}
   As opções \texttt{repeatfields}, \texttt{repeattitles}, \texttt{backref},
-  \texttt{nosl}, \texttt{nosn}, \texttt{noslsn}, \texttt{extrayear} e \texttt{slashdaterange} também
+  \texttt{nosl}, \texttt{nosn}, \texttt{noslsn}, \texttt{extrayear}, \texttt{dateyear}, \texttt{datemonth} e \texttt{slashdaterange} também
   podem ser usadas apenas em entradas específicas. E.g.:
 \end{sloppypar}
 
@@ -214,6 +216,13 @@ Ou, um exemplo de uso do \texttt{slashdaterange}:
 
     Que resulta em:
     \singlecite{lucca2009}
+
+As opções \texttt{dateyear} e \texttt{datemonth} também podem ser aplicadas apenas para tipos específicos de entradas, através do comando \verb|\ExecuteBibliographyOptions|. E. g.:
+
+\begin{verbatim}
+    \ExecuteBibliographyOptions[book]{dateyear}
+    \ExecuteBibliographyOptions[article]{datemonth}
+\end{verbatim}
     
 % <<<2
 

--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -974,14 +974,42 @@
 % <<<2
 
 % Options to define type of date per entrytype >>>2
-% Para utilizar as options, utilize \ExecuteBibliographyOptions[entrytype], e. g.:
-% \ExecuteBibliographyOptions[article]{datemonth}
-\DeclareTypeOption[boolean]{dateyear}[true]{%
-\xpretobibmacro{date}{\clearfield{day}\clearfield{month}}{}{}%
+% Options to show only years
+\DeclareBiblatexOption{global, type, entry}[boolean]{dateyear}[true]{%
+\renewbibmacro*{date}{\mkdaterangeyear{}}%
 }%
-\DeclareTypeOption[boolean]{datemonth}[true]{%
-\xpretobibmacro{date}{\clearfield{day}}{}{}%
+
+% Options to show years and months
+% O comando abaixo é o \mkdaterangeyear adaptado para não remover o mês
+\newrobustcmd*{\mkdaterangeyearmonth}[1]{%
+\begingroup
+  \clearfield{yeardivision}%
+  % \clearfield{#1month}%
+  \clearfield{day}%
+  \clearfield{hour}%
+  \clearfield{minute}%
+  \clearfield{second}%
+  \clearfield{timezone}%
+  \clearfield{endyeardivision}%
+  % \clearfield{#1endmonth}%
+  \clearfield{endday}%
+  \clearfield{endhour}%
+  \clearfield{endminute}%
+  \clearfield{endsecond}%
+  \clearfield{endtimezone}%
+  \ifdaterangesequal{#1}{#1end}
+    {\clearfield{#1endmonth}
+      \clearfield{#1endyear}}
+    {\ifdateyearsequal{#1}{#1end}
+      {\blx@imc@clearfield{#1endyear}}
+      {}%
+    }%
+  \mkdaterangefull{long}{#1}%
+\endgroup}
+\DeclareBiblatexOption{global, type, entry}[boolean]{datemonth}[true]{%
+\renewbibmacro*{date}{\mkdaterangeyearmonth{}}%
 }%
+% <<<2
 
 % <<<1
 

--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -973,6 +973,17 @@
 }%
 % <<<2
 
+% Options to define type of date per entrytype >>>2
+% O option dateyear é desnecessário por causa que o biblatex já apresenta o date=year, mas adicionei para manter o padrão com o datemonth. O recomendado seria utilizar date=year
+% Para utilizar as options, utilize \ExecuteBibliographyOptions:
+% \ExecuteBibliographyOptions[article]{datemonth}
+\DeclareTypeOption[boolean]{dateyear}[true]{%
+\xpretobibmacro{date}{\clearfield{day}\clearfield{month}}{}{}%
+}%
+\DeclareTypeOption[boolean]{datemonth}[true]{%
+\xpretobibmacro{date}{\clearfield{day}}{}{}%
+}%
+
 % <<<1
 
 

--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -974,8 +974,7 @@
 % <<<2
 
 % Options to define type of date per entrytype >>>2
-% O option dateyear é desnecessário por causa que o biblatex já apresenta o date=year, mas adicionei para manter o padrão com o datemonth. O recomendado seria utilizar date=year
-% Para utilizar as options, utilize \ExecuteBibliographyOptions:
+% Para utilizar as options, utilize \ExecuteBibliographyOptions[entrytype], e. g.:
 % \ExecuteBibliographyOptions[article]{datemonth}
 \DeclareTypeOption[boolean]{dateyear}[true]{%
 \xpretobibmacro{date}{\clearfield{day}\clearfield{month}}{}{}%


### PR DESCRIPTION
Criei duas opções para a impressão da data das entradas, `dateyear` e `datemonth`. Elas estão configuradas para poderem ser utilizadas de forma global, por tipo de entrada ou por entrada. Essas duas opções resolvem o "problema" relatado no issue #73 . 
A `dateyear` remove todas as outras partes de sua data, restando apenas o ano, e a `datemonth` remove todas também, porém, deixando o mês e ano intocados. As opções também consideram os intervalos, apesar de eu não ter testado tanto a opção `datemonth` neste aspecto.
Também adicionei à documentação a descrição das duas opções.

Uma limitação: as opções afetam somente o campo `date` e seus campos variantes (`year`, `month`, `endyear`, etc.). Outros campos, como o `eventdate` não são impactados (eu na verdade queria alterar o comportamento do `eventdate`, mas todas as entradas que utilizam o campo usam o `\printeventdate` ao invés de utilizar uma `bibmacro` exclusiva para imprimir o `eventdate`, igual ocorre no campo `date`).