### PR TITLE
Fix biblatex "Ignoring mapping" warning (#35)

### DIFF
--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -24,7 +24,16 @@
 \RequirePackage{xpatch}%
 \RequirePackage{expl3}%
 
-\DeclareLanguageMappingSuffix{-abnt}
+\DeclareLanguageMapping{american}{american-abnt}
+\DeclareLanguageMapping{australian}{australian-abnt}
+\DeclareLanguageMapping{brazil}{brazil-abnt}
+\DeclareLanguageMapping{brazilian}{brazilian-abnt}
+\DeclareLanguageMapping{british}{british-abnt}
+\DeclareLanguageMapping{canadian}{canadian-abnt}
+\DeclareLanguageMapping{english}{english-abnt}
+\DeclareLanguageMapping{portuges}{portuges-abnt}
+\DeclareLanguageMapping{portuguese}{portuguese-abnt}
+\DeclareLanguageMapping{spanish}{spanish-abnt}
 
 \RequireBibliographyStyle{standard}%
 


### PR DESCRIPTION
By explicitly identifying all mappings supported for the package, we can fix the warning without breaking existing documents.