### PR TITLE
Corrigir espaços a mais em URL e Data de Acesso

### DIFF
--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -1020,6 +1020,7 @@
 }%
 % <<<2
 
+% This removes <> in URLs according to abnt-6023:2018
 \DeclareFieldFormat{url}{\bibstring{urlfrom}\addcolon\addspace\url{#1}}%
 \DeclareFieldFormat{urldate}{\bibstring{urlseen}\addcolon\addspace #1}%
 
@@ -1516,10 +1517,6 @@
 }%% <<<
 
 \DeclareFieldFormat{illustrated}{\addspace #1\isdot}%
-
-% remove <> in URLs according to abnt-6023:2018
-\DeclareFieldFormat{url}{\textmainlang{\bibstring{urlfrom}\addcolon\addspace \url{#1}}}
-\DeclareFieldFormat{urldate}{\textmainlang{\bibstring{urlseen}\addcolon\addspace #1}}%
 
 \DeclareFieldFormat*{note}{\addspace #1}%
 


### PR DESCRIPTION
Este PR resolve provisoriamente o issue https://github.com/abntex/biblatex-abnt/issues/128

Os espaços a mais são adicionados pelo comando \textmainlang de babel. Talvez seja necessário abrir um issue upstream.

O usuário pode definir o idioma da lista de referências usando \selectlanguage (babel) antes do \printbibliography. O manual de abntex2 também explica o uso de \selectlanguage