### PR TITLE
Formata a string "apud" em itálico nas citações, conforme NBR 10520:2023

### DIFF
--- a/latex/cbx/abnt-ibid.cbx
+++ b/latex/cbx/abnt-ibid.cbx
@@ -501,12 +501,12 @@
 \newcommand{\addapud}{%% >>>2
   \renewcommand*{\multicitedelim}{%
     \ifnumequal{\value{multicitecount}}{\value{multicitetotal}}%
-      {\space\bibstring{apud}}%
+      {\space\mkbibitalic{\bibstring{apud}}}%
       {\addsemicolon}%
     \space}%
   \renewcommand*{\textcitedelim}{%
     \ifnumequal{\value{multicitecount}}{\value{multicitetotal}}%
-      {\addspace\bibstring{apud}}%
+      {\space\mkbibitalic{\bibstring{apud}}}%
       {\addsemicolon}%
     \space}%
 }% <<<2
@@ -517,7 +517,7 @@
         \usebibmacro{prenote}%
       }{%
         \printfield[uppercasecite]{prenote}%
-        \isdot\addspace\bibstring{apud}\addspace%
+        \isdot\addspace\mkbibitalic{\bibstring{apud}}\addspace%
       }%
     }%
   }%

--- a/latex/cbx/abnt.cbx
+++ b/latex/cbx/abnt.cbx
@@ -634,17 +634,17 @@
 \newcommand{\addapud}{%% >>>3
   \renewcommand*{\compcitedelim}{%
     \ifnumequal{\value{multicitecount}}{\value{multicitetotal}}%
-      {\space\bibstring{apud}}%
+      {\space\mkbibitalic{\bibstring{apud}}}%
       {\addsemicolon}%
     \space}%
   \renewcommand*{\multicitedelim}{%
     \ifnumequal{\value{multicitecount}}{\value{multicitetotal}}%
-      {\space\bibstring{apud}}%
+      {\space\mkbibitalic{\bibstring{apud}}}%
       {\addsemicolon}%
     \space}%
   \renewcommand*{\textcitedelim}{%
     \ifnumequal{\value{multicitecount}}{\value{multicitetotal}}%
-      {\addspace\bibstring{apud}}%
+      {\addspace\mkbibitalic{\bibstring{apud}}}%
       {\addsemicolon}%
     \space}%
 }% <<<3
@@ -656,7 +656,7 @@
         \usebibmacro{prenote}%
       }{%
         \printfield[uppercasecite]{prenote}%
-        \isdot\addspace\bibstring{apud}\addspace%
+        \isdot\addspace\mkbibitalic{\bibstring{apud}}\addspace%
       }%
     }%
   }%
@@ -709,12 +709,12 @@
       }\addspace%
       \IfNoValueTF{#5}{%
           \IfNoValueTF{#4}{%
-            \plaincite[\blx@imc@bibxstring{apud}][]{#6}%
+            \plaincite[\mkbibitalic{\blx@imc@bibxstring{apud}}][]{#6}%
           }{%
-            \plaincite[\blx@imc@bibxstring{apud}][#4]{#6}%
+            \plaincite[\mkbibitalic{\blx@imc@bibxstring{apud}}][#4]{#6}%
           }%
       }{%
-          \cite[\blx@imc@bibxstring{apud} #4][#5]{#6}%
+          \cite[\mkbibitalic{\blx@imc@bibxstring{apud}} #4][#5]{#6}%
       }%
   }%
 }%% <<<3


### PR DESCRIPTION
A atualização mais recente da ABNT NBR 10520 (2023) reforçou a regra de que expressões de origem latina precisam ser grafadas em itálico. Ao transicionar do `abntex2` para o `biblatex-abnt`, notei que o pacote ainda não estava aplicando esse estilo automaticamente na string do _“apud”_ nas citações de citações.

Para resolver isso, fiz um ajuste direto no arquivo `latex/cbx/abnt.cbx`. A alteração embute o itálico na própria macro, garantindo que o documento compile com a norma atualizada e poupando os usuários de criarem contornos manuais — que eu mesmo estava fazendo noutro momento. Rodei testes locais e a mudança funcionou conforme o esperado, sem quebrar o comportamento dos outros comandos de citação.

Como esta é a minha primeira contribuição para o projeto, fiquem à vontade para apontar correções caso prefiram que essa estilização seja feita de outra forma na arquitetura atual do código.