### PR TITLE
Adiciona suporte inicial à ABNT NBR 6023:2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [Unreleased]
+
+### Changed
+- Make the event city optional, as required by NBR 6023:2025
+- Omit unknown publisher and location markers from online documents
+- Add a dedicated `jurisdiction` driver with an abbreviated judgment date
+
+
 ## [3.4] - 2018-11-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # biblatex-abnt
 [![Build Status](https://travis-ci.org/abntex/biblatex-abnt.svg?branch=master)](https://travis-ci.org/abntex/biblatex-abnt)
+[![NBR 6023:2025](https://img.shields.io/badge/NBR%206023%3A2025-adequa%C3%A7%C3%A3o%20inicial-yellow.svg)](doc/NBR6023-2025.md)
+[![NBR 6023:2018 100%](https://img.shields.io/badge/NBR%206023%3A2018-100%25-brightgreen.svg)](https://github.com/abntex/biblatex-abnt/blob/master/tests/NBR6023-2018_reference.pdf)
 [![NBR 6023:2002 100%](https://img.shields.io/badge/NBR%206023%3A2002-100%25-brightgreen.svg)](https://github.com/abntex/biblatex-abnt/blob/master/tests/NBR6023-2002_reference.pdf)
 [![NBR 10520:2002 100%](https://img.shields.io/badge/NBR%2010520%3A2002-100%25-brightgreen.svg)](https://github.com/abntex/biblatex-abnt/blob/master/tests/NBR10520-2002_reference.pdf)
 
@@ -12,6 +14,10 @@ Version 3.4
 ---
 
 Estilo para BibLaTeX compatível com as normas da ABNT.
+
+O desenvolvimento atual adota como referência a **ABNT NBR 6023:2025**,
+terceira edição da norma de elaboração de referências. As alterações em
+relação à edição de 2018 possuem casos de regressão próprios.
 
 Versão 3.4
 
@@ -54,4 +60,30 @@ suas entradas.
 3. Use o comando `\printbibliography` para imprimir a bibliografia.
 
 *Consulte [o arquivo biblatex-abnt.pdf](https://github.com/abntex/biblatex-abnt/raw/master/doc/biblatex-abnt.pdf) e o [manual do biblatex](http://mirrors.ctan.org/macros/latex/contrib/biblatex/doc/biblatex.pdf) para informações sobre as opções e comandos disponíveis.*
+
+## Base normativa
+
+A referência normativa principal do estilo é:
+
+> ASSOCIAÇÃO BRASILEIRA DE NORMAS TÉCNICAS. **ABNT NBR 6023:2025:
+> Informação e documentação — Referências — Elaboração**. 3. ed.
+> Rio de Janeiro: ABNT, 2025. 68 p.
+
+Consulte [a nota de implementação da NBR 6023:2025](doc/NBR6023-2025.md)
+para conhecer o escopo, os campos BibLaTeX adotados e os testes relacionados.
+A norma pode ser adquirida ou consultada pelos meios autorizados no
+[Catálogo da ABNT](https://www.abntcatalogo.com.br/).
+
+O texto integral da norma não é distribuído neste repositório.
+
+## Testes normativos
+
+- NBR 6023:2002: exemplos normativos e
+  [PDF de saída validada](tests/NBR6023-2002_reference.pdf).
+- NBR 6023:2018: exemplos normativos e
+  [PDF de saída validada](tests/NBR6023-2018_reference.pdf).
+- NBR 6023:2025: regressões das alterações da terceira edição em
+  [`tests/NBR6023-2025-regressions.tex`](tests/NBR6023-2025-regressions.tex)
+  e
+  [`tests/NBR6023-2025-regressions.bib`](tests/NBR6023-2025-regressions.bib).
 

--- a/doc/NBR6023-2025.md
+++ b/doc/NBR6023-2025.md
@@ -1,0 +1,42 @@
+# ABNT NBR 6023:2025
+
+O desenvolvimento atual do `biblatex-abnt` adota como referência principal:
+
+> ASSOCIAÇÃO BRASILEIRA DE NORMAS TÉCNICAS. **ABNT NBR 6023:2025:
+> Informação e documentação — Referências — Elaboração**. 3. ed.
+> Rio de Janeiro: ABNT, 2025. 68 p.
+
+- Terceira edição: 21 de maio de 2025.
+- Substitui a ABNT NBR 6023:2018.
+- Incorpora o conteúdo da Emenda 1 à edição de 2018.
+- Página oficial: [Catálogo da ABNT](https://www.abntcatalogo.com.br/).
+
+O texto integral da norma é protegido por direitos autorais e não é
+redistribuído neste repositório.
+
+## Implementação
+
+As mudanças da edição de 2025 cobertas pelo estilo incluem:
+
+- cidade do evento opcional;
+- identificador eletrônico de artigo pelo campo `eid`;
+- data de julgamento de jurisprudência pelo campo `eventdate`;
+- omissão de local e editora desconhecidos em documentos com `url`;
+- manutenção dos indicadores `[S. l.]` e `[s. n.]` para documentos impressos;
+- suplemento, número especial e informações semelhantes depois da data.
+- entrevistado como autor principal em referências de entrevistas;
+- ISSN como elemento opcional;
+- DOI e ORCID como elementos complementares.
+
+Para jurisprudência, `eventdate` representa a data do julgamento e `date`
+representa a data da publicação.
+
+## Testes
+
+Os casos focados nas alterações da terceira edição estão em:
+
+- [`tests/NBR6023-2025-regressions.tex`](../tests/NBR6023-2025-regressions.tex);
+- [`tests/NBR6023-2025-regressions.bib`](../tests/NBR6023-2025-regressions.bib).
+
+Esses arquivos são testes de regressão das mudanças entre edições. Eles não
+reproduzem nem substituem o texto integral da norma.

--- a/doc/biblatex-abnt.tex
+++ b/doc/biblatex-abnt.tex
@@ -113,6 +113,22 @@ Para instalá-lo manualmente, copie os arquivos \texttt{.bbx}, \texttt{.cbx} e
 e atualize o banco de dados do TeX (rodando o `texhash`, por exemplo).
 % <<<2
 
+\section{Base normativa}% >>>2
+
+O desenvolvimento atual do estilo adota como referência principal a terceira
+edição da norma:
+
+\begin{quote}
+  ASSOCIAÇÃO BRASILEIRA DE NORMAS TÉCNICAS. \textbf{ABNT NBR 6023:2025:
+  Informação e documentação --- Referências --- Elaboração}. 3. ed.
+  Rio de Janeiro: ABNT, 2025. 68 p.
+\end{quote}
+
+Os documentos de teste das edições de 2002 e 2018 são preservados para
+compatibilidade histórica. As alterações introduzidas em 2025 são cobertas
+por casos de regressão específicos no diretório \texttt{tests}.
+% <<<2
+
 \section{Uso}% >>>2
 
 Para usar o {biblatex-abnt}, adicione as seguintes linhas ao preâmbulo do seu
@@ -224,6 +240,11 @@ As opções \texttt{dateyear} e \texttt{datemonth} também podem ser aplicadas a
     \ExecuteBibliographyOptions[book]{dateyear}
     \ExecuteBibliographyOptions[article]{datemonth}
 \end{verbatim}
+
+De acordo com a NBR 6023:2025, as indicações de local e editora desconhecidos
+não são impressas quando a entrada possui o campo \texttt{url}. Para documentos
+impressos, as indicações continuam sendo impressas e podem ser controladas
+manualmente pelas opções \texttt{nosl}, \texttt{nosn} e \texttt{noslsn}.
     
 % <<<2
 
@@ -734,6 +755,29 @@ Um artigo científico/acadêmico:
 \end{verbatim}
 
 \singlecite{negrão14}
+% <<<3
+
+\subsection{@jurisdiction}% >>>3
+
+Para jurisprudência, o campo \texttt{eventdate} registra a data do julgamento,
+enquanto \texttt{date} registra a data da publicação. A expressão
+\enquote{julgado em} e a data abreviada são geradas automaticamente:
+
+\begin{verbatim}
+    @jurisdiction{stf2005,
+        author       = {{Brasil}},
+        nameaddon    = {Supremo Tribunal Federal (2. Turma)},
+        title        = {Recurso Extraordinário 313060/SP.
+                        Relatora: Min. Ellen Gracie},
+        eventdate    = {2005-11-29},
+        journaltitle = {Lex},
+        location     = {São Paulo},
+        volume       = {28},
+        number       = {327},
+        pages        = {226-230},
+        date         = {2006},
+    }
+\end{verbatim}
 % <<<3
 
 \subsection{@thesis}% >>>3

--- a/latex/bbx/abnt.bbx
+++ b/latex/bbx/abnt.bbx
@@ -533,22 +533,39 @@
   \printunit{\addperiod\addspace}%
 }%
 
+\newbibmacro*{judgmentdate}{%% >>>3
+  \iffieldundef{eventyear}%
+    {}%
+    {\printtext{\bibstring{judgedon}\addspace}%
+     \printeventdate}%
+}%% <<<3
+
 \newbibmacro*{publisher}{%% >>>3
   \iflistundef{publisher}%
-    {\iftoggle{nosn}{}{\printtext[brackets]{\mkbibemph{\bibstring{sinenomine}}}}}%
+    {\ifboolexpr{%
+       test {\iftoggle{nosn}}%
+       or%
+       not test {\iffieldundef{url}}%
+     }%
+       {}%
+       {\printtext[brackets]{\mkbibemph{\bibstring{sinenomine}}}}}%
       {\printlist{publisher}}%
 }%% <<<3
 
 \newbibmacro*{location}{%% >>>3
   \iflistundef{location}%
-    {\iftoggle{nosl}{}{\printtext[brackets]{\mkbibemph{\bibstring{sineloco}}}}}%
+    {\ifboolexpr{%
+       test {\iftoggle{nosl}}%
+       or%
+       not test {\iffieldundef{url}}%
+     }%
+       {}%
+       {\printtext[brackets]{\mkbibemph{\bibstring{sineloco}}}}}%
       {\printlist{location}}%
 }%% <<<3
 
 \newbibmacro*{venue}{%% >>>3
-  \iffieldundef{venue}%
-    {\iftoggle{nosl}{}{\printtext[brackets]{\mkbibemph{\bibstring{sineloco}}}}}%
-      {\printfield{venue}}%
+  \printfield{venue}%
 }%% <<<3
 
 \renewbibmacro*{location+date}{%% >>>3
@@ -567,6 +584,8 @@
     not test {\iftoggle{nosl}}%
     and%
     not test {\iftoggle{nosn}}%
+    and%
+    test {\iffieldundef{url}}%
   }{%
     \printtext[brackets]{\mkbibemph{\bibstring{sineloco}}%
     \setunit{\addcolon\addnbspace}%
@@ -624,6 +643,8 @@
     not test {\iftoggle{nosl}}%
     and%
     not test {\iftoggle{nosn}}%
+    and%
+    test {\iffieldundef{url}}%
   }{%
     \printtext[brackets]{\mkbibemph{\bibstring{sineloco}}%
     \setunit{\addcolon\addnbspace}%
@@ -1370,7 +1391,6 @@
 \DeclareNameAlias{withafterword}{given-family}%
 
 \DeclareBibliographyAlias{legislation}{article}%
-\DeclareBibliographyAlias{jurisdiction}{article}%
 \DeclareBibliographyAlias{legal}{article}%
 
 % Name delimiters >>>3
@@ -1623,6 +1643,73 @@
   \usebibmacro{author/organization}%
   \setunit{\labelnamepunct}%
   \usebibmacro{title}\newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \printlist{language}%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \usebibmacro{byauthor}%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \usebibmacro{byeditor+others}\newunit%
+  \usebibmacro{bytranslator+others}%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \printfield{version}%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \iffieldundef{relatedtype}{}{%
+    \bibstring{\strfield{relatedtype}}}%
+  \setunit*{\addcolon\addspace}%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \usebibmacro{journal+section}%
+  \setunit*{\addcomma\addspace}%
+  \printlist{publisher}%
+  \setunit*{\addcomma\addspace}%
+  \printlist{location}%
+  \setunit*{\addcomma\addspace}%
+  \usebibmacro{volume+number+eid}%
+  \setunit{\addcomma\addspace}%
+  \printfield{pages}%
+  \setunit*{\addcomma\addspace}%
+  \printfield{pagetotal}%
+  \setunit{\addcomma\addspace}%
+  \usebibmacro{issue+date}%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \printfield{note}%
+  \printunit{\addperiod\addspace}%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \iftoggle{bbx:isbn}%
+    {\printfield{issn}}%
+    {}%
+    \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \usebibmacro{doi+eprint+url}%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \usebibmacro{addendum+pubstate}%
+  \setunit{\bibpagerefpunct}%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \usebibmacro{pageref}%
+  \setunit*{\addperiod\addspace}%
+  \newunit%
+  \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  \iftoggle{bbx:related}%
+    {\usebibmacro{related:init}%
+    \usebibmacro{related}}%
+    {}%
+  \usebibmacro{finentry}%
+}%% <<<2
+
+\DeclareBibliographyDriver{jurisdiction}{%% >>>2
+  \usebibmacro{bibindex}%
+  \usebibmacro{begentry}%
+  \usebibmacro{author/organization}%
+  \setunit{\labelnamepunct}%
+  \usebibmacro{title}%
+  \setunit{\addcomma\addspace}%
+  \usebibmacro{judgmentdate}%
+  \newunit%
   \newblock%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   \printlist{language}%
   \newunit%

--- a/latex/lbx/brazilian-abnt.lbx
+++ b/latex/lbx/brazilian-abnt.lbx
@@ -68,6 +68,7 @@
   apud,%
   sineloco,%
   sinenomine,%
+  judgedon,%
   sheet,%
   sheets,%
   sheettotal,%
@@ -90,6 +91,7 @@
   inseries     = {{in}{in}},%
   sineloco     = {{sine loco}{s\adddot~l\adddot}},%
   sinenomine   = {{sine nomine}{s\adddot~n\adddot}},%
+  judgedon     = {{julgado em}{julgado em}},%
   urlfrom      = {{dispon\'ivel em}{dispon\'ivel em}},%
   urlseen      = {{acesso em}{acesso em}},%
   sheet        = {{folha}{f\adddot}},%

--- a/latex/lbx/english-abnt.lbx
+++ b/latex/lbx/english-abnt.lbx
@@ -68,6 +68,7 @@
   apud,%
   sineloco,%
   sinenomine,%
+  judgedon,%
   sheet,%
   sheets,%
   illustrated,%
@@ -87,6 +88,7 @@
   inseries         = {{in}{in}},%
   sineloco         = {{sine loco}{s\adddot~l\adddot}},%
   sinenomine       = {{sine nomine}{s\adddot~n\adddot}},%
+  judgedon         = {{judged on}{judged on}},%
   sheet            = {{sheet}{s\adddot}},%
   sheets           = {{sheets}{s\adddot}},%
   illustrated      = {{illustrated}{il\adddot}},%

--- a/latex/lbx/french-abnt.lbx
+++ b/latex/lbx/french-abnt.lbx
@@ -69,6 +69,7 @@
   apud,%
   sineloco,%
   sinenomine,%
+  judgedon,%
   sheet,%
   sheets,%
   illustrated,%
@@ -88,6 +89,7 @@
   inseries         = {{in}{in}},%
   sineloco         = {{sine loco}{s\adddot l\adddot}},%
   sinenomine       = {{sine nomine}{s\adddot n\adddot}},%
+  judgedon         = {{jug\'e le}{jug\'e le}},%
   sheet            = {{feuille}{f\adddot}},%
   sheets           = {{feuilles}{f\adddot}},%
   illustrated      = {{illustr\'e}{il\adddot}},%

--- a/latex/lbx/german-abnt.lbx
+++ b/latex/lbx/german-abnt.lbx
@@ -21,6 +21,11 @@
   inherit = {german},%
 }%
 
+\NewBibliographyString{judgedon}%
+\DeclareBibliographyStrings{%
+  judgedon = {{entschieden am}{entschieden am}},%
+}%
+
 % Months abbreviations >>>1
 \DeclareBibliographyStrings{%
     january          = {{Januar}{Jan\adddot}},

--- a/latex/lbx/italian-abnt.lbx
+++ b/latex/lbx/italian-abnt.lbx
@@ -21,6 +21,11 @@
   inherit = {italian},%
 }%
 
+\NewBibliographyString{judgedon}%
+\DeclareBibliographyStrings{%
+  judgedon = {{giudicato il}{giudicato il}},%
+}%
+
 % Months abbreviations >>>1
 \DeclareBibliographyStrings{%
   january          = {{gennaio}{genn\adddot}},

--- a/latex/lbx/spanish-abnt.lbx
+++ b/latex/lbx/spanish-abnt.lbx
@@ -69,6 +69,7 @@
   apud,%
   sineloco,%
   sinenomine,%
+  judgedon,%
   sheet,%
   sheets,%
   illustrated,%
@@ -88,6 +89,7 @@
   inseries         = {{in}{in}},%
   sineloco         = {{sine loco}{s\adddot~l\adddot}},%
   sinenomine       = {{sine nomine}{s\adddot~n\adddot}},%
+  judgedon         = {{juzgado el}{juzgado el}},%
   urlfrom          = {{disponible en}{disponible en}},%
   urlseen          = {{acceso en}{acceso en}},%
   sheet            = {{hoja}{h\adddot}},%

--- a/tests/NBR6023-2025-regressions.bib
+++ b/tests/NBR6023-2025-regressions.bib
@@ -1,0 +1,114 @@
+@proceedings{event-without-venue,
+  eventtitle = {Congresso Brasileiro de Biblioteconomia},
+  number     = {30},
+  eventdate  = {2025},
+  title      = {Anais},
+  location   = {Brasília, DF},
+  publisher  = {FEBAB},
+  date       = {2025},
+}
+
+@proceedings{event-with-venue,
+  eventtitle = {Congresso Brasileiro de Biblioteconomia},
+  number     = {30},
+  eventdate  = {2025},
+  venue      = {Recife},
+  title      = {Anais},
+  location   = {Brasília, DF},
+  publisher  = {FEBAB},
+  date       = {2025},
+}
+
+@article{article-with-elocation,
+  keywords     = {elocation},
+  author       = {Silva, Ana},
+  title        = {Preservação digital},
+  journaltitle = {Revista Brasileira de Biblioteconomia},
+  location     = {Brasília, DF},
+  volume       = {21},
+  number       = {2},
+  eid          = {e202501},
+  date         = {2025},
+}
+
+@jurisdiction{judgment-with-date,
+  author       = {{Brasil}},
+  nameaddon    = {Supremo Tribunal Federal (2. Turma)},
+  title        = {Recurso Extraordinário 313060/SP. Leis 10.927/91 e 11.262
+                  do município de São Paulo. Seguro obrigatório contra furto
+                  e roubo de automóveis. Relatora: Min. Ellen Gracie},
+  eventdate    = {2005-11-29},
+  journaltitle = {Lex},
+  journalsubtitle = {jurisprudência do Supremo Tribunal Federal},
+  location     = {São Paulo},
+  volume       = {28},
+  number       = {327},
+  pages        = {226-230},
+  date         = {2006},
+}
+
+@book{exclusively-electronic,
+  author  = {Souza, Beatriz},
+  title   = {Preservação de documentos digitais},
+  date    = {2025},
+  url     = {https://example.org/preservacao},
+  urldate = {2025-06-10},
+}
+
+@book{unknown-print-publication,
+  author = {Souza, Beatriz},
+  title  = {Preservação de documentos impressos},
+  date   = {2025},
+}
+
+@article{periodical-supplement,
+  keywords     = {supplement},
+  title        = {Indicadores culturais brasileiros},
+  journaltitle = {Revista Brasileira de Cultura},
+  location     = {Brasília, DF},
+  volume       = {18},
+  number       = {1},
+  date         = {2025-03},
+  note         = {Suplemento},
+}
+
+@article{interview-with-interviewee-as-author,
+  keywords     = {interview},
+  author       = {Hamel, Gary},
+  title        = {Eficiência não basta},
+  subtitle     = {as empresas precisam inovar na gestão},
+  editor       = {Stanley, Chris},
+  editortype   = {interviewer},
+  journaltitle = {HSM Management},
+  location     = {São Paulo},
+  number       = {79},
+  date         = {2010-03/2010-04},
+}
+
+@periodical{periodical-with-issn,
+  title     = {Revista Brasileira de Biblioteconomia},
+  location  = {Brasília, DF},
+  publisher = {FEBAB},
+  date      = {2020/},
+  issn      = {0000-0000},
+}
+
+@periodical{periodical-without-issn,
+  title     = {Cadernos de Preservação Digital},
+  location  = {Recife},
+  publisher = {Editora Exemplo},
+  date      = {2021/},
+}
+
+@article{article-with-doi-and-orcid,
+  keywords     = {identifiers},
+  author       = {Carberry, Josiah},
+  title        = {Identificadores persistentes em referências},
+  journaltitle = {Revista de Documentação},
+  volume       = {10},
+  number       = {1},
+  pages        = {1-12},
+  date         = {2025},
+  note         = {ORCID: 0000-0002-1825-0097},
+  doi          = {10.1234/exemplo.2025.1},
+}

--- a/tests/NBR6023-2025-regressions.tex
+++ b/tests/NBR6023-2025-regressions.tex
@@ -1,0 +1,81 @@
+\documentclass[a4paper]{article}
+
+\usepackage[brazilian]{babel}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage[style=abnt,sorting=none]{biblatex}
+\usepackage[autostyle]{csquotes}
+
+\addbibresource{NBR6023-2025-regressions.bib}
+
+\begin{document}
+
+\section*{NBR 6023:2025 -- regressões}
+
+\subsection*{Cidade do evento opcional}
+
+\nocite{event-without-venue,event-with-venue}
+\printbibliography[
+  heading=none,
+  type=proceedings,
+]
+
+\subsection*{\textit{e-location} em artigo de periódico}
+
+\nocite{article-with-elocation}
+\printbibliography[
+  heading=none,
+  type=article,
+  keyword=elocation,
+]
+
+\subsection*{Data de julgamento}
+
+\nocite{judgment-with-date}
+\printbibliography[
+  heading=none,
+  type=jurisdiction,
+]
+
+\subsection*{Documento exclusivamente eletrônico}
+
+\nocite{exclusively-electronic,unknown-print-publication}
+\printbibliography[
+  heading=none,
+  type=book,
+]
+
+\subsection*{Suplemento após a data}
+
+\nocite{periodical-supplement}
+\printbibliography[
+  heading=none,
+  keyword=supplement,
+]
+
+\subsection*{Entrevistado como autor}
+
+\nocite{interview-with-interviewee-as-author}
+\printbibliography[
+  heading=none,
+  keyword=interview,
+]
+
+\subsection*{ISSN opcional}
+
+\nocite{periodical-with-issn,periodical-without-issn}
+\printbibliography[
+  heading=none,
+  type=periodical,
+]
+
+\subsection*{DOI e ORCID como elementos complementares}
+
+\nocite{article-with-doi-and-orcid}
+\printbibliography[
+  heading=none,
+  keyword=identifiers,
+]
+
+\end{document}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,33 +1,57 @@
 
 # biblatex-abnt/tests
 
-- The files `NBR10520-2002.tex` and `NBR6023-2002.tex` use the biblatex-abnt
-  style to print every entry mentioned on the respective ABNT rules.
+- The files `NBR10520-2002.tex`, `NBR6023-2002.tex`, and
+  `NBR6023-2018.tex` use the biblatex-abnt style to print every entry
+  mentioned in the respective ABNT standards.
 
-- The files `NBR10520-2002_reference.pdf` and `NBR6023-2002_reference.pdf` are
-  the latest compilation of the files above that was manually checked against
-  ABNT's rules and confirmed to be accurate.
+- The files `NBR10520-2002_reference.pdf`, `NBR6023-2002_reference.pdf`, and
+  `NBR6023-2018_reference.pdf` are the latest compilations of the files above
+  that were manually checked against ABNT's rules and confirmed to be
+  accurate. They contain generated test output, not copies of the standards.
 
-- The files `NBR10520-2002_test.tex` and `NBR6023-2002_test.tex` compare the
-  reference files with a current compilation (which has to be generated from
-  the original tex files), making it easy to check if the style has strayed
-  from the rules.
+- The files `NBR10520-2002_test.tex`, `NBR6023-2002_test.tex`, and
+  `NBR6023-2018_test.tex` compare the reference files with a current
+  compilation (which has to be generated from the original tex files), making
+  it easy to check if the style has strayed from the rules.
 
 - The `test.sh` script automates that last step.
+  It sets `TEXINPUTS` explicitly so the tests use the style files from the
+  working tree instead of a globally installed version.
+
+- The files `NBR6023-2025-regressions.tex` and
+  `NBR6023-2025-regressions.bib` contain focused regression cases for changes
+  introduced by NBR 6023:2025. They currently cover an event with no city and
+  the electronic article identifier (`eid`, or e-location), judgment dates,
+  online documents without publication details, periodical supplements,
+  interviewees as authors, optional ISSN, and DOI/ORCID identifiers.
 
 ---
 
-- Os arquivos `NBR10520-2002.tex` e `NBR6023-2002.tex` usam o biblatex-abnt
-  para imprimir todas as entradas citadas nas respectivas normas.
+- Os arquivos `NBR10520-2002.tex`, `NBR6023-2002.tex` e
+  `NBR6023-2018.tex` usam o biblatex-abnt para imprimir todas as entradas
+  citadas nas respectivas normas.
 
-- Os arquivos `NBR10520-2002_reference.pdf` e `NBR6023-2002_reference.pdf` são
-  a última compilação dos arquivos acima que foi manualmente comparada à norma
-  da ABNT com um resultado favorável.
+- Os arquivos `NBR10520-2002_reference.pdf`, `NBR6023-2002_reference.pdf` e
+  `NBR6023-2018_reference.pdf` são as compilações mais recentes dos arquivos
+  acima que foram manualmente comparadas às normas da ABNT com um resultado
+  favorável. Eles contêm saídas de teste geradas, não cópias das normas.
 
-- Os arquivos `NBR10520-2002_test.tex` e `NBR6023-2002_test.tex` comparam os
-  arquivos de referência com uma compilação atual (que deve ser gerada
-  a partir dos arquivos tex originais), permitindo visualizar facilmente os
-  pontos em que o estilo distanciou-se da norma.
+- Os arquivos `NBR10520-2002_test.tex`, `NBR6023-2002_test.tex` e
+  `NBR6023-2018_test.tex` comparam os arquivos de referência com uma
+  compilação atual (que deve ser gerada a partir dos arquivos tex originais),
+  permitindo visualizar facilmente os pontos em que o estilo distanciou-se
+  da norma.
 
 - O script `test.sh` automatiza esse último passo.
+  Ele define `TEXINPUTS` explicitamente para que os testes usem os arquivos
+  de estilo da árvore de trabalho, em vez de uma versão instalada globalmente.
+
+- Os arquivos `NBR6023-2025-regressions.tex` e
+  `NBR6023-2025-regressions.bib` contêm casos de regressão focados nas
+  alterações introduzidas pela NBR 6023:2025. No momento, eles cobrem um
+  evento sem cidade e o identificador eletrônico de artigo (`eid`, ou
+  e-location), datas de julgamento, documentos online sem dados de publicação
+  e suplementos de periódicos, entrevistados como autores, ISSN opcional e
+  identificadores DOI/ORCID.
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2,9 +2,19 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export TEXINPUTS="$REPO_DIR/latex/bbx//:$REPO_DIR/latex/cbx//:$REPO_DIR/latex/lbx//:${TEXINPUTS:-}"
+
 echo "Running tests..."
 
 pass=true
+
+
+pdflatex -draftmode -interaction=batchmode NBR6023-2025-regressions.tex
+biber NBR6023-2025-regressions
+pdflatex -draftmode -interaction=batchmode NBR6023-2025-regressions.tex
+pdflatex -draftmode -interaction=batchmode NBR6023-2025-regressions.tex
 
 
 sed -i.bak 's/\\toggletrue{reference}/% \\toggletrue{reference}/' NBR10520-2002.tex


### PR DESCRIPTION
## Resumo

Adiciona a adequação inicial do `biblatex-abnt` à ABNT NBR 6023:2025, preservando o comportamento existente para referências impressas e os testes históricos das edições de 2002 e 2018.

## Alterações

- torna opcional a cidade do evento;
- adiciona cobertura de regressão para localizadores eletrônicos de artigos pelo campo `eid`;
- cria um driver específico para `jurisdiction`, com a data abreviada do julgamento precedida por “julgado em”;
- omite os indicadores de local e editora desconhecidos em documentos online, mantendo-os nos documentos impressos;
- posiciona suplemento, número especial e informações semelhantes depois da data de publicação;
- adiciona as traduções necessárias para a data de julgamento;
- registra a ABNT NBR 6023:2025 como referência normativa atual, sem redistribuir o texto protegido da norma;
- acrescenta regressões focadas em cidade do evento, e-location, jurisprudência, documentos online, suplementos, entrevistado como autor, ISSN opcional, DOI e ORCID;
- garante que o script de testes carregue os arquivos da árvore de trabalho por meio de `TEXINPUTS`, evitando uma versão global antiga.

## Motivação

A terceira edição da ABNT NBR 6023 foi publicada em 2025 e substitui a edição de 2018. Algumas mudanças afetam diretamente a geração das referências, especialmente eventos, documentos online, identificadores eletrônicos de artigos e jurisprudência.

## Validação

- compilação da regressão focada da NBR 6023:2025 com os arquivos locais do estilo;
- asserções textuais sobre as saídas esperadas;
- inspeção visual do PDF de regressão;
- compilação dos exemplos da NBR 6023:2018 com o estilo atualizado;
- compilação e inspeção visual do manual;
- execução bem-sucedida de `git diff --check`.

A comparação visual histórica completa é afetada por diferenças entre os PDFs de referência antigos e o TeX Live 2026. A regressão focada de 2025 não depende dessa limitação conhecida.

---

## English summary

Adds the initial adaptation of `biblatex-abnt` to ABNT NBR 6023:2025 while preserving the existing behavior for print references and the historical 2002/2018 fixtures.

The changes cover optional event cities, article electronic locators, judgment dates, online documents without unknown publication markers, periodical supplements, interviewees as authors, optional ISSN, DOI, and ORCID. Documentation and focused regression tests are included.

Validation included compilation with the local style files, semantic output assertions, visual PDF inspection, compilation of the 2018 examples and project manual, and `git diff --check`.
